### PR TITLE
Fix: db and test-db containers binding to same port if DB_PORT is set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     env_file:
       - .env.test
     ports:
-      - ${DB_PORT:-54321}:5432
+      - ${TEST_DB_PORT:-54321}:5432
     environment:
       - POSTGRES_SERVER=test-db
       - POSTGRES_USER=test


### PR DESCRIPTION
Changed test-db to read from TEST_DB_PORT to avoid binding errors when DB_PORT is defined.