### PR TITLE
Fix CORS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Backend
 RUN_ENV=local
-BACKEND_CORS_ORIGINS=[http://localhost]
+BACKEND_CORS_ORIGINS=["http://localhost"]
 PROJECT_NAME="fast-api-template"
 SERVER_NAME=localhost
 SERVER_HOST=http://localhost:8000/

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     SECRET_KEY: str = secrets.token_urlsafe(32)
     SERVER_NAME: str
     SERVER_HOST: AnyHttpUrl
-    BACKEND_CORS_ORIGINS: Union[str, List[str]] = []
+    BACKEND_CORS_ORIGINS: Union[List[str], str] = []
     PROJECT_NAME: str
     AUTHENTICATION_API_RATE_LIMIT: str = "5 per minute"
     SECURE_COOKIE: bool = True


### PR DESCRIPTION
## Problem

The `BACKEND_CORS_ORIGINS` env in `config.py` is typed as `Union[str, List[str]]`. Pydantic never parses this env as a list because it attempts to cast unions in order, and str always succeeds.

## Solution

Reverse the type annotation, to `Union[List[str], str]` so it tries to cast to a list first.

Also, correctly write the example in `.env.example` so that it's clear how to add many domains to the allowed list.